### PR TITLE
Resolver Test Cases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ before_install:
   - go get github.com/mattn/goveralls
 script:
   - go build -ldflags="-s -w"
-  - go test -race -covermode atomic -coverprofile=profile.cov ./...
-  - $HOME/gopath/bin/goveralls -service=travis-ci
+  - bash coverage.sh
+  - $HOME/gopath/bin/goveralls -service=travis-ci -coverprofile=.cover/cover.out
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ before_install:
   - go get github.com/mattn/goveralls
 script:
   - go build -ldflags="-s -w"
+  - go test -race -covermode atomic -coverprofile=profile.cov ./...
   - $HOME/gopath/bin/goveralls -service=travis-ci
 notifications:
   email: false

--- a/cloudflare/cloudflare_test.go
+++ b/cloudflare/cloudflare_test.go
@@ -1,0 +1,1 @@
+package cloudflare

--- a/config.yaml
+++ b/config.yaml
@@ -27,7 +27,7 @@ cloudflare:
   # List of the hostnames you would like to update. There is no default.
   hostnames:
     - <hostname-1>
-    - <hostname-2
+    - <hostname-2>
 
 worker:
   # Check interval in seconds.

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,0 +1,1 @@
+package config

--- a/coverage.sh
+++ b/coverage.sh
@@ -2,7 +2,7 @@ set -e
 
 workdir=.cover
 profile="$workdir/cover.out"
-mode=count
+mode=atomic
 
 generate_cover_data() {
     rm -rf "$workdir"
@@ -10,7 +10,7 @@ generate_cover_data() {
 
     for pkg in "$@"; do
         f="$workdir/$(echo $pkg | tr / -).cover"
-        go test -covermode="$mode" -coverprofile="$f" "$pkg"
+        go test -race -covermode="$mode" -coverprofile="$f" "$pkg"
     done
 
     echo "mode: $mode" >"$profile"

--- a/logger/logger_test.go
+++ b/logger/logger_test.go
@@ -1,5 +1,1 @@
-/*
- * test for http: contains all tests for logger utilities
- */
-
 package logger

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,1 @@
+package main

--- a/resolver/base.go
+++ b/resolver/base.go
@@ -51,7 +51,7 @@ var (
 
 // Resolver is the base service
 type Resolver interface {
-	Init() error
+	Init()
 	GetExternalIP() (net.IP, error)
 }
 
@@ -87,11 +87,7 @@ func Get(key string) (*Resolver, error) {
 		return nil, err
 	}
 
-	err := resolver.Init()
-	if err != nil {
-		logger.Error(err.Error())
-		return nil, err
-	}
+	resolver.Init()
 	logger.Debug("Resolver [%s] initiated...", key)
 	return &resolver, nil
 }

--- a/resolver/base_test.go
+++ b/resolver/base_test.go
@@ -1,0 +1,1 @@
+package resolver

--- a/resolver/base_test.go
+++ b/resolver/base_test.go
@@ -2,6 +2,9 @@ package resolver
 
 import (
 	"fmt"
+	"io/ioutil"
+	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/kerti/cloudflare-ddns/logger"
@@ -23,6 +26,12 @@ func getJSONResolver(url string) *Resolver {
 	var resolver Resolver
 	resolver = &JSON{URL: url}
 	return &resolver
+}
+
+func mockHTTPResponse(input string) *http.Response {
+	return &http.Response{
+		Body: ioutil.NopCloser(strings.NewReader(input)),
+	}
 }
 
 func TestBase(t *testing.T) {

--- a/resolver/base_test.go
+++ b/resolver/base_test.go
@@ -1,1 +1,24 @@
 package resolver
+
+import (
+	"testing"
+
+	"github.com/kerti/cloudflare-ddns/logger"
+	"github.com/stretchr/testify/assert"
+)
+
+var (
+	// initial loglevel for mocking logger
+	initloglevel uint8 = uint8(0)
+)
+
+func TestBase(t *testing.T) {
+
+	logger.InitLogger(&initloglevel)
+
+	t.Run("GetAll", func(t *testing.T) {
+		res, err := GetAll()
+		assert.Equal(t, nil, err)
+		assert.Equal(t, len(ResolverURLs), len(res))
+	})
+}

--- a/resolver/base_test.go
+++ b/resolver/base_test.go
@@ -1,6 +1,7 @@
 package resolver
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/kerti/cloudflare-ddns/logger"
@@ -12,13 +13,83 @@ var (
 	initloglevel uint8 = uint8(0)
 )
 
+func getSimpleResolver(url string) *Resolver {
+	var resolver Resolver
+	resolver = &Simple{URL: url}
+	return &resolver
+}
+
+func getJSONResolver(url string) *Resolver {
+	var resolver Resolver
+	resolver = &JSON{URL: url}
+	return &resolver
+}
+
 func TestBase(t *testing.T) {
 
 	logger.InitLogger(&initloglevel)
 
+	t.Run("Get", func(t *testing.T) {
+		testCases := []struct {
+			name   string
+			key    string
+			result *Resolver
+			err    error
+		}{
+			{
+				name:   "emptyKey",
+				key:    "",
+				result: nil,
+				err:    fmt.Errorf("unsupported resolver: "),
+			},
+			{
+				name:   "randomKey",
+				key:    "someRandomText",
+				result: nil,
+				err:    fmt.Errorf("unsupported resolver: someRandomText"),
+			},
+			{
+				name:   "validJSONResolverKey",
+				key:    ResolverBigDataCloud,
+				result: getSimpleResolver(ResolverURLs[ResolverBigDataCloud]),
+				err:    nil,
+			},
+			{
+				name:   "validSimpleResolverKey",
+				key:    ResolverICanHazIP,
+				result: getJSONResolver(ResolverURLs[ResolverICanHazIP]),
+				err:    nil,
+			},
+		}
+
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				result, err := Get(tc.key)
+				assert.Equal(t, tc.result == nil, result == nil)
+				assert.Equal(t, tc.err, err)
+			})
+		}
+	})
+
 	t.Run("GetAll", func(t *testing.T) {
-		res, err := GetAll()
-		assert.Equal(t, nil, err)
-		assert.Equal(t, len(ResolverURLs), len(res))
+
+		t.Run("normal", func(t *testing.T) {
+			res, err := GetAll()
+			assert.Nil(t, err)
+			assert.Equal(t, len(ResolverURLs), len(res))
+		})
+
+		t.Run("error", func(t *testing.T) {
+			key := "randomString"
+			ResolverURLs[key] = key
+
+			res, err := GetAll()
+
+			assert.Equal(t, fmt.Errorf("unsupported resolver: %v", key), err)
+			assert.Nil(t, res)
+
+			delete(ResolverURLs, key)
+		})
+
 	})
 }

--- a/resolver/json.go
+++ b/resolver/json.go
@@ -25,13 +25,12 @@ type JSON struct {
 }
 
 // Init initializes the resolver
-func (j *JSON) Init() error {
+func (j *JSON) Init() {
 	j.HTTPClient = &http.Client{
 		Transport: &http.Transport{
 			TLSClientConfig: &tls.Config{InsecureSkipVerify: viper.GetBool("ipResolver.noVerify")},
 		},
 	}
-	return nil
 }
 
 // GetExternalIP invokes the URL and fetches the external IP returned

--- a/resolver/json.go
+++ b/resolver/json.go
@@ -53,6 +53,12 @@ func (j *JSON) GetExternalIP() (net.IP, error) {
 }
 
 func (j *JSON) readIP(r *http.Response) (net.IP, error) {
+	if r == nil {
+		err := fmt.Errorf("response is nil")
+		logger.Error(err.Error())
+		return nil, err
+	}
+
 	bodyBytes, err := ioutil.ReadAll(r.Body)
 	if err != nil {
 		logger.Error(err.Error())
@@ -67,8 +73,15 @@ func (j *JSON) readIP(r *http.Response) (net.IP, error) {
 	}
 
 	ipObj := kvMap[j.JSONPath]
+	if ipObj == nil {
+		err = fmt.Errorf("IP address not found at path [%s]", j.JSONPath)
+		logger.Error(err.Error())
+		return nil, err
+	}
+
 	ipString, ok := ipObj.(string)
 	if !ok {
+		err = fmt.Errorf("cannot convert value at path [%s] to string: %v", j.JSONPath, ipObj)
 		logger.Error(err.Error())
 		return nil, err
 	}

--- a/resolver/json_test.go
+++ b/resolver/json_test.go
@@ -1,0 +1,1 @@
+package resolver

--- a/resolver/json_test.go
+++ b/resolver/json_test.go
@@ -1,1 +1,102 @@
 package resolver
+
+import (
+	"net"
+	"testing"
+
+	"github.com/kerti/cloudflare-ddns/logger"
+	"github.com/stretchr/testify/assert"
+)
+
+var (
+	// test vars go here
+	jsonReadIPTestCases = []struct {
+		name     string
+		jsonPath string
+		response string
+		result   net.IP
+		errIsNil bool
+		errMsg   string
+	}{
+		{
+			name:     "emptyResponse",
+			jsonPath: "path",
+			response: "",
+			result:   nil,
+			errIsNil: false,
+			errMsg:   "unexpected end of JSON input",
+		},
+		{
+			name:     "plaintextResponse",
+			jsonPath: "path",
+			response: "1.2.3.4",
+			result:   nil,
+			errIsNil: false,
+			errMsg:   "invalid character '.' after top-level value",
+		},
+		{
+			name:     "validSimpleJSONResponseWithInvalidPath",
+			jsonPath: "invalidPath",
+			response: `{"ipAddress": "1.2.3.4"}`,
+			result:   nil,
+			errIsNil: false,
+			errMsg:   "IP address not found at path [invalidPath]",
+		},
+		{
+			name:     "validSimpleJSONResponseWithInvalidValueType",
+			jsonPath: "ipAddress",
+			response: `{"ipAddress": true}`,
+			result:   nil,
+			errIsNil: false,
+			errMsg:   "cannot convert value at path [ipAddress] to string: true",
+		},
+		{
+			name:     "validSimpleJSONResponseWithInvalidValue",
+			jsonPath: "ipAddress",
+			response: `{"ipAddress": "somerandomtext"}`,
+			result:   nil,
+			errIsNil: false,
+			errMsg:   "cannot parse IP: somerandomtext",
+		},
+		{
+			name:     "validSimpleJSONResponse",
+			jsonPath: "ipAddress",
+			response: `{"ipAddress": "1.2.3.4"}`,
+			result:   net.ParseIP("1.2.3.4"),
+			errIsNil: true,
+			errMsg:   "",
+		},
+	}
+)
+
+func TestJSONResolver(t *testing.T) {
+
+	logger.InitLogger(&initloglevel)
+
+	t.Run("readIP", func(t *testing.T) {
+
+		resolver := JSON{
+			URL: "",
+		}
+
+		t.Run("nilResponse", func(t *testing.T) {
+			result, err := resolver.readIP(nil)
+			assert.Nil(t, result)
+			assert.NotNil(t, err)
+			assert.Equal(t, "response is nil", err.Error())
+		})
+
+		for _, tc := range jsonReadIPTestCases {
+			t.Run(tc.name, func(t *testing.T) {
+				resolver.JSONPath = tc.jsonPath
+				result, err := resolver.readIP(mockHTTPResponse(tc.response))
+				assert.Equal(t, tc.result, result)
+				if tc.errIsNil {
+					assert.Nil(t, err)
+				} else {
+					assert.Equal(t, tc.errMsg, err.Error())
+				}
+			})
+		}
+	})
+}

--- a/resolver/simple.go
+++ b/resolver/simple.go
@@ -52,15 +52,8 @@ func (s *Simple) GetExternalIP() (net.IP, error) {
 }
 
 func (s *Simple) readIP(r *http.Response) (net.IP, error) {
-	if r == nil {
-		err := fmt.Errorf("response is nil")
-		logger.Error(err.Error())
-		return nil, err
-	}
-
-	bodyBytes, err := ioutil.ReadAll(r.Body)
+	bodyBytes, err := s.getResponseBody(r)
 	if err != nil {
-		logger.Error(err.Error())
 		return nil, err
 	}
 
@@ -80,4 +73,20 @@ func (s *Simple) readIP(r *http.Response) (net.IP, error) {
 
 	logger.Debug("[RSLV-SIMP] [%s] Detected external IP: %v", s.URL, parsedIP)
 	return parsedIP, nil
+}
+
+func (s *Simple) getResponseBody(r *http.Response) ([]byte, error) {
+	if r == nil {
+		err := fmt.Errorf("response is nil")
+		logger.Error(err.Error())
+		return nil, err
+	}
+
+	bodyBytes, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		logger.Error(err.Error())
+		return nil, err
+	}
+
+	return bodyBytes, nil
 }

--- a/resolver/simple.go
+++ b/resolver/simple.go
@@ -52,6 +52,12 @@ func (s *Simple) GetExternalIP() (net.IP, error) {
 }
 
 func (s *Simple) readIP(r *http.Response) (net.IP, error) {
+	if r == nil {
+		err := fmt.Errorf("response is nil")
+		logger.Error(err.Error())
+		return nil, err
+	}
+
 	bodyBytes, err := ioutil.ReadAll(r.Body)
 	if err != nil {
 		logger.Error(err.Error())

--- a/resolver/simple.go
+++ b/resolver/simple.go
@@ -24,13 +24,12 @@ type Simple struct {
 }
 
 // Init initializes the resolver
-func (s *Simple) Init() error {
+func (s *Simple) Init() {
 	s.HTTPClient = &http.Client{
 		Transport: &http.Transport{
 			TLSClientConfig: &tls.Config{InsecureSkipVerify: viper.GetBool("ipResolver.noVerify")},
 		},
 	}
-	return nil
 }
 
 // GetExternalIP invokes the URL and fetches the external IP returned

--- a/resolver/simple_test.go
+++ b/resolver/simple_test.go
@@ -13,8 +13,6 @@ import (
 )
 
 var (
-	// initial loglevel for mocking logger
-	initloglevel uint8 = uint8(0)
 	// test vars go here
 	readIPTestCases = []struct {
 		name     string

--- a/resolver/simple_test.go
+++ b/resolver/simple_test.go
@@ -2,10 +2,7 @@ package resolver
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net"
-	"net/http"
-	"strings"
 	"testing"
 
 	"github.com/kerti/cloudflare-ddns/logger"
@@ -14,7 +11,7 @@ import (
 
 var (
 	// test vars go here
-	readIPTestCases = []struct {
+	simpleReadIPTestCases = []struct {
 		name     string
 		response string
 		result   net.IP
@@ -53,21 +50,24 @@ var (
 	}
 )
 
-func mockHTTPResponse(input string) *http.Response {
-	return &http.Response{
-		Body: ioutil.NopCloser(strings.NewReader(input)),
-	}
-}
-
 func TestSimpleResolver(t *testing.T) {
 
 	logger.InitLogger(&initloglevel)
 
 	t.Run("readIP", func(t *testing.T) {
+
 		resolver := Simple{
 			URL: "",
 		}
-		for _, tc := range readIPTestCases {
+
+		t.Run("nilResponse", func(t *testing.T) {
+			result, err := resolver.readIP(nil)
+			assert.Nil(t, result)
+			assert.NotNil(t, err)
+			assert.Equal(t, "response is nil", err.Error())
+		})
+
+		for _, tc := range simpleReadIPTestCases {
 			t.Run(tc.name, func(t *testing.T) {
 				result, err := resolver.readIP(mockHTTPResponse(tc.response))
 				assert.Equal(t, tc.result, result)

--- a/resolver/simple_test.go
+++ b/resolver/simple_test.go
@@ -74,5 +74,6 @@ func TestSimpleResolver(t *testing.T) {
 				assert.Equal(t, tc.err, err)
 			})
 		}
+
 	})
 }

--- a/resolver/simple_test.go
+++ b/resolver/simple_test.go
@@ -1,0 +1,80 @@
+package resolver
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/kerti/cloudflare-ddns/logger"
+	"github.com/stretchr/testify/assert"
+)
+
+var (
+	// initial loglevel for mocking logger
+	initloglevel uint8 = uint8(0)
+	// test vars go here
+	readIPTestCases = []struct {
+		name     string
+		response string
+		result   net.IP
+		err      error
+	}{
+		{
+			name:     "emptyResponse",
+			response: "",
+			result:   nil,
+			err:      fmt.Errorf("cannot parse IP: "),
+		},
+		{
+			name:     "validIpAddress",
+			response: "1.2.3.4",
+			result:   net.ParseIP("1.2.3.4"),
+			err:      nil,
+		},
+		{
+			name:     "invalidIpAddress",
+			response: "1.2.3.256",
+			result:   nil,
+			err:      fmt.Errorf("cannot parse IP: 1.2.3.256"),
+		},
+		{
+			name:     "validIpAddressWithNewline",
+			response: "1.2.3.4\n",
+			result:   net.ParseIP("1.2.3.4"),
+			err:      nil,
+		},
+		{
+			name:     "validIpAddressWithQuotes",
+			response: `"1.2.3.4"`,
+			result:   net.ParseIP("1.2.3.4"),
+			err:      nil,
+		},
+	}
+)
+
+func mockHTTPResponse(input string) *http.Response {
+	return &http.Response{
+		Body: ioutil.NopCloser(strings.NewReader(input)),
+	}
+}
+
+func TestSimpleResolver(t *testing.T) {
+
+	logger.InitLogger(&initloglevel)
+
+	t.Run("readIP", func(t *testing.T) {
+		resolver := Simple{
+			URL: "",
+		}
+		for _, tc := range readIPTestCases {
+			t.Run(tc.name, func(t *testing.T) {
+				result, err := resolver.readIP(mockHTTPResponse(tc.response))
+				assert.Equal(t, tc.result, result)
+				assert.Equal(t, tc.err, err)
+			})
+		}
+	})
+}

--- a/worker/worker_test.go
+++ b/worker/worker_test.go
@@ -1,0 +1,1 @@
+package worker


### PR DESCRIPTION
## In This PR

* Added most of the test cases for resolver package.
* Refactored somewhat to prevent too many return statements.

## Ideas

* Refactor to create a single resolver type to cater for all kinds of resolvers.
* Don't hardcode the resolver configs; set them in the config file instead.