### PR TITLE
Automatic Check Intervals

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -63,12 +63,11 @@ cloudflare:
 
 worker:
   # Check interval in seconds.
-  # Minimum: 10 (to prevent bursting a bunch of checks)
+  # Minimum: 300 / number of resolvers (minimum 5 minutes round interval)
   # Maximum: 4294967295 (uint32 max value)
-  # Defaults to 35, the reasoning being that there are currently 9 resolvers implemented.
-  # With 35 seconds between checks, a resolver will be invoked at most once every 5 minutes.
-  # This gives the fastest check interval without irresponsibly invoking any resolver.
-  # checkInterval: 35
+  # Recommended: auto (will automatically calculate optimum interval)
+  # Defaults to auto
+  # checkInterval: auto
 
 # Notifier configuration
 notifier:

--- a/config/config.go
+++ b/config/config.go
@@ -22,7 +22,7 @@ func Load(optConfig *string) error {
 	/* set default config values */
 	viper.SetDefault("loglevel", 3)
 	viper.SetDefault("resolver.noVerify", true)
-	viper.SetDefault("worker.checkInterval", 35)
+	viper.SetDefault("worker.checkInterval", "auto")
 
 	viper.SetDefault("notifier.ifttt.webhook.active", false)
 	viper.SetDefault("notifier.ifttt.webhook.eventName", "cf_ddns_update")

--- a/main.go
+++ b/main.go
@@ -56,12 +56,6 @@ func initialize() error {
 		return err
 	}
 
-	err = worker.CheckConfig()
-	if err != nil {
-		logger.Error(err.Error())
-		return err
-	}
-
 	return nil
 }
 

--- a/resolver/resolver_test.go
+++ b/resolver/resolver_test.go
@@ -234,10 +234,10 @@ func mockHTTPResponse(input string) *http.Response {
 func TestResolver(t *testing.T) {
 
 	logger.InitLogger(&initloglevel)
+	configFile := "../config.yaml"
+	config.Load(&configFile)
 
 	t.Run("Get", func(t *testing.T) {
-		configFile := "../config.yaml"
-		config.Load(&configFile)
 		res, err := Get()
 		assert.NotNil(t, res)
 		assert.NotEmpty(t, res)

--- a/worker/worker_test.go
+++ b/worker/worker_test.go
@@ -1,1 +1,147 @@
 package worker
+
+import (
+	"testing"
+
+	"github.com/kerti/cloudflare-ddns/config"
+	"github.com/kerti/cloudflare-ddns/logger"
+	"github.com/kerti/cloudflare-ddns/resolver"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+)
+
+var (
+	initloglevel uint8 = uint8(0)
+
+	initIntervalTestCases = []struct {
+		name          string
+		configValue   string
+		resolverCount int
+		intervalValue int
+	}{
+		{
+			name:          "emptyConfig",
+			configValue:   "",
+			resolverCount: 6,
+			intervalValue: 50,
+		},
+		{
+			name:          "randomString",
+			configValue:   "randomString",
+			resolverCount: 3,
+			intervalValue: 100,
+		},
+		{
+			name:          "auto1",
+			configValue:   "auto",
+			resolverCount: 1,
+			intervalValue: 300,
+		},
+		{
+			name:          "auto2",
+			configValue:   "auto",
+			resolverCount: 2,
+			intervalValue: 150,
+		},
+		{
+			name:          "auto3",
+			configValue:   "auto",
+			resolverCount: 3,
+			intervalValue: 100,
+		},
+		{
+			name:          "auto4",
+			configValue:   "auto",
+			resolverCount: 4,
+			intervalValue: 75,
+		},
+		{
+			name:          "auto5",
+			configValue:   "auto",
+			resolverCount: 5,
+			intervalValue: 60,
+		},
+		{
+			name:          "auto6",
+			configValue:   "auto",
+			resolverCount: 6,
+			intervalValue: 50,
+		},
+		{
+			name:          "auto7",
+			configValue:   "auto",
+			resolverCount: 7,
+			intervalValue: 43,
+		},
+		{
+			name:          "auto8",
+			configValue:   "auto",
+			resolverCount: 8,
+			intervalValue: 38,
+		},
+		{
+			name:          "auto9",
+			configValue:   "auto",
+			resolverCount: 9,
+			intervalValue: 33,
+		},
+		{
+			name:          "auto10",
+			configValue:   "auto",
+			resolverCount: 10,
+			intervalValue: 30,
+		},
+		{
+			name:          "auto",
+			configValue:   "auto11",
+			resolverCount: 11,
+			intervalValue: 30,
+		},
+		{
+			name:          "manual-10-30",
+			configValue:   "30",
+			resolverCount: 10,
+			intervalValue: 30,
+		},
+		{
+			name:          "manual-10-40",
+			configValue:   "40",
+			resolverCount: 10,
+			intervalValue: 40,
+		},
+		{
+			name:          "manual-10-20",
+			configValue:   "20",
+			resolverCount: 10,
+			intervalValue: 30,
+		},
+		{
+			name:          "zeroResolvers",
+			configValue:   "",
+			resolverCount: 0,
+			intervalValue: 300,
+		},
+	}
+)
+
+func TestWorker(t *testing.T) {
+
+	logger.InitLogger(&initloglevel)
+	configFile := "../config.yaml"
+	config.Load(&configFile)
+
+	t.Run("getInterval", func(t *testing.T) {
+
+		worker := Worker{}
+
+		for _, tc := range initIntervalTestCases {
+			t.Run(tc.name, func(t *testing.T) {
+				viper.Set("worker.checkInterval", tc.configValue)
+				worker.Resolvers = make([]resolver.Resolver, tc.resolverCount)
+				worker.initInterval()
+				assert.Equal(t, tc.intervalValue, worker.Interval)
+			})
+		}
+
+	})
+}


### PR DESCRIPTION
Implement automatic check interval setting:

* Calculate the optimal check interval based on the number of available providers. At most, a provider will be invoked once approximately every 5 minutes. This is to prevent irresponsibly using someone's free service.
* Do not check more than twice per minute. It's useless and bogs down the network.

Hence the optimal number of providers is 10, as it will result in an automatically set check interval of 30 seconds and a round interval of 5 minutes.

We're one provider short of achieving this.